### PR TITLE
Fix #6 re-linking execs on repeat builds

### DIFF
--- a/src/smart-build.sh
+++ b/src/smart-build.sh
@@ -721,9 +721,9 @@ run_tests() {
   fi
 }
 
-move_execs() {
-  [ -e "${executable_name}" ] && mv "${executable_name}" ..
-  [ -e "${test_driver_name}" ] && mv "${test_driver_name}" ..
+copy_execs() {
+  [ -e "${executable_name}" ] && cp "${executable_name}" ..
+  [ -e "${test_driver_name}" ] && cp "${test_driver_name}" ..
 }
 
 build_and_test() {
@@ -736,7 +736,7 @@ build_and_test() {
   create_and_switch_to_build_dir
   build_project
   run_tests
-  move_execs
+  copy_execs
 }
 
 main() {

--- a/tests/unit_tests/compile_link_test.sh
+++ b/tests/unit_tests/compile_link_test.sh
@@ -1,0 +1,144 @@
+#!/bin/sh
+
+################################################################################
+# ENV VARS
+#   unit_test_function  optional single test function to run in this file
+################################################################################
+
+################################################################################
+# LOAD COMMON VARS
+################################################################################
+
+#shellcheck source=../unit_test_vars.sh
+. ../unit_test_vars.sh
+
+################################################################################
+# SETUP / TEARDOWN
+################################################################################
+
+setUp() {
+  #shellcheck source=../per_test_setup.sh
+  . ../per_test_setup.sh
+  writeConfigFiles
+}
+
+tearDown() {
+  # shellcheck source=../per_test_teardown.sh
+  . ../../per_test_teardown.sh
+}
+
+################################################################################
+# HELPER FUNCTIONS
+################################################################################
+
+writeConfigFiles() {
+  ./${EXEC_NAME} --generate-project-config --generate-cmakelists
+}
+
+################################################################################
+# UNIT TESTS
+################################################################################
+
+buildWithoutTests() {
+  cmd_output=$(./${EXEC_NAME} -d)
+  exit_code=${?}
+  assertContains 'buildWithoutTests linking exec' "${cmd_output}" 'Linking CXX executable my-exec'
+  assertContains 'buildWithoutTests building exec' "${cmd_output}" 'Built target my-exec'
+  assertTrue 'buildWithoutTests exec exists' '[ -e my-exec ]'
+  assertFalse 'buildWithoutTests test-driver exists' '[ -e my-test-driver ]'
+  assertEquals 'buildWithoutTests exit code' "${exit_code}" 0
+}
+
+repeatBuildWithoutTests() {
+  cmd_output=$(./${EXEC_NAME} -d)
+  cmd_output=$(./${EXEC_NAME} -d)
+  exit_code=${?}
+  assertNotContains 'buildWithoutTests linking exec' "${cmd_output}" 'Linking CXX executable my-exec'
+  assertContains 'buildWithoutTests building exec' "${cmd_output}" 'Built target my-exec'
+  assertTrue 'buildWithoutTests exec exists' '[ -e my-exec ]'
+  assertFalse 'buildWithoutTests test-driver exists' '[ -e my-test-driver ]'
+  assertEquals 'buildWithoutTests exit code' "${exit_code}" 0
+}
+
+buildWithTests() {
+  cmd_output=$(./${EXEC_NAME} -dt)
+  exit_code=${?}
+  assertContains 'buildWithTests linking exec' "${cmd_output}" 'Linking CXX executable my-exec'
+  assertContains 'buildWithTests building exec' "${cmd_output}" 'Built target my-exec'
+  assertContains 'buildWithTests linking test-driver' "${cmd_output}" 'Linking CXX executable my-test-driver'
+  assertContains 'buildWithTests building test-driver' "${cmd_output}" 'Built target my-test-driver'
+  assertContains 'buildWithTests tests passed' "${cmd_output}" '100% tests passed, 0 tests failed'
+  assertTrue 'buildWithTests exec exists' '[ -e my-exec ]'
+  assertTrue 'buildWithTests test-driver exists' '[ -e my-test-driver ]'
+  assertEquals 'buildWithTests exit code' "${exit_code}" 0
+}
+
+repeatBuildWithTests() {
+  cmd_output=$(./${EXEC_NAME} -dt)
+  cmd_output=$(./${EXEC_NAME} -dt)
+  exit_code=${?}
+  assertNotContains 'repeatBuildWithTests linking exec' "${cmd_output}" 'Linking CXX executable my-exec'
+  assertContains 'repeatBuildWithTests building exec' "${cmd_output}" 'Built target my-exec'
+  assertNotContains 'repeatBuildWithTests linking test-driver' "${cmd_output}" 'Linking CXX executable my-test-driver'
+  assertContains 'repeatBuildWithTests building test-driver' "${cmd_output}" 'Built target my-test-driver'
+  assertContains 'repeatBuildWithTests tests passed' "${cmd_output}" '100% tests passed, 0 tests failed'
+  assertTrue 'repeatBuildWithTests exec exists' '[ -e my-exec ]'
+  assertTrue 'repeatBuildWithTests test-driver exists' '[ -e my-test-driver ]'
+  assertEquals 'repeatBuildWithTests exit code' "${exit_code}" 0
+}
+
+buildTestsOnly() {
+  cmd_output=$(./${EXEC_NAME} -dtE)
+  exit_code=${?}
+  assertNotContains 'buildTestsOnly linking exec' "${cmd_output}" 'Linking CXX executable my-exec'
+  assertNotContains 'buildTestsOnly building exec' "${cmd_output}" 'Built target my-exec'
+  assertContains 'buildTestsOnly linking test-driver' "${cmd_output}" 'Linking CXX executable my-test-driver'
+  assertContains 'buildTestsOnly building test-driver' "${cmd_output}" 'Built target my-test-driver'
+  assertContains 'buildTestsOnly tests passed' "${cmd_output}" '100% tests passed, 0 tests failed'
+  assertFalse 'buildTestsOnly exec exists' '[ -e my-exec ]'
+  assertTrue 'buildTestsOnly test-driver exists' '[ -e my-test-driver ]'
+  assertEquals 'buildTestsOnly exit code' "${exit_code}" 0
+}
+
+repeatBuildTestsOnly() {
+  cmd_output=$(./${EXEC_NAME} -dtE)
+  cmd_output=$(./${EXEC_NAME} -dtE)
+  exit_code=${?}
+  assertNotContains 'repeatBuildTestsOnly linking exec' "${cmd_output}" 'Linking CXX executable my-exec'
+  assertNotContains 'repeatBuildTestsOnly building exec' "${cmd_output}" 'Built target my-exec'
+  assertNotContains 'repeatBuildTestsOnly linking test-driver' "${cmd_output}" 'Linking CXX executable my-test-driver'
+  assertContains 'repeatBuildTestsOnly building test-driver' "${cmd_output}" 'Built target my-test-driver'
+  assertContains 'repeatBuildTestsOnly tests passed' "${cmd_output}" '100% tests passed, 0 tests failed'
+  assertFalse 'repeatBuildTestsOnly exec exists' '[ -e my-exec ]'
+  assertTrue 'repeatBuildTestsOnly test-driver exists' '[ -e my-test-driver ]'
+  assertEquals 'repeatBuildTestsOnly exit code' "${exit_code}" 0
+}
+
+################################################################################
+# TEST SUITE
+################################################################################
+
+suite() {
+  # shellcheck disable=SC2154
+  if [ "${unit_test_function}" != ''  ] && [ "$( type -t "${unit_test_function}" )" = "function" ]; then
+    suite_addTest "${unit_test_function}"
+  else
+    suite_addTest buildWithoutTests
+    suite_addTest repeatBuildWithoutTests
+    suite_addTest buildWithTests
+    suite_addTest repeatBuildWithTests
+    suite_addTest buildTestsOnly
+    suite_addTest repeatBuildTestsOnly
+  fi
+}
+
+################################################################################
+# LOAD TEST FRAMEWORK (MUST GO LAST)
+################################################################################
+
+# zsh compatibility options
+export SHUNIT_PARENT=$0
+setopt shwordsplit 2> /dev/null
+# shellcheck disable=SC1091
+. "${PATH_TO_SHUNIT}"
+


### PR DESCRIPTION
## Description

Copy main-exec and test-driver to project dir from build dir after building (prevents unncecessary re-linking). Fixes #6.

## Type Of Change

- [ X ] New feature (non-breaking change which adds functionality)

## Tests Performed

All unit tests pass when run under all shells.

**Test Configuration**:
* Hardware: Quad-Core i7, 16 GB RAM
* OS: Arch Linux
* OS Release/Distribution: N/A 
* Date Of Last OS Update: (up-to-date Jan 2019)
* Compiler Version: GCC 8.2.1
* Shell: bash, mksh, dash, zsh

## Checklist:

- [X] My code follows the style of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation. N/A.
- [X] My changes generate no new warnings.
- [X] I have added tests that prove my fix is effective or that my feature
      works.
- [X] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream
      modules. N/A.