### PR TITLE
Close #1: add cmd-line opt to use gnu/llvm compiler

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -159,8 +159,8 @@ USAGE
 `smart-build.sh  -c|-C  [-b <dir>]  [-p <file>]  [-e <file>]`  
 &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; `[-x <file>]  [-q]`
 
-`smart-build.sh  -d|-r|-w|-m  [-c|-C]  [-t|-T]  [-b <dir>]`  
-&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; `[-p <file>]  [-e <file>|-E]  [-x <file>]  [-q]`
+`smart-build.sh  -d|-r|-w|-m  [-c|-C]  [-g|-l]  [-t|-T]`  
+&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; `[-b <dir>]  [-p <file>]  [-e <file>|-E]  [-x <file>]  [-q]`
 
 `smart-build.sh  -P  [-L]  [-V]`
 
@@ -190,6 +190,12 @@ OPTIONS:
 
 `-C, --clean-executables`  
 &nbsp; &nbsp; &nbsp; &nbsp; remove built program/testing executables
+
+`-g, --use-gnu-compiler`  
+&nbsp; &nbsp; &nbsp; &nbsp; use GNU gcc/g++ compiler and linker
+
+`-l, --use-llvm-compiler`  
+&nbsp; &nbsp; &nbsp; &nbsp; use LLVM clang/clang++ compiler and linker
 
 `-t, --make-and-run-tests`  
 &nbsp; &nbsp; &nbsp; &nbsp; make and run tests
@@ -254,6 +260,12 @@ OPTIONS:
 
    ```bash
    $ ./smart-build -cd
+   ```
+
+* Build and force use of LLVM compiler (instead of system's default compiler):
+
+   ```bash
+   $ ./smart-build -dl
    ```
 
 * Build in specified out-of-source _CMake_ build directory (default is `build`):

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ addons:
     packages:
     - gcc-7
     - g++-7
+    - clang
     - mksh
     - zsh
 

--- a/tests/unit_tests/compiler_option_test.sh
+++ b/tests/unit_tests/compiler_option_test.sh
@@ -1,0 +1,99 @@
+#!/bin/sh
+
+################################################################################
+# ENV VARS
+#   unit_test_function  optional single test function to run in this file
+################################################################################
+
+################################################################################
+# LOAD COMMON VARS
+################################################################################
+
+#shellcheck source=../unit_test_vars.sh
+. ../unit_test_vars.sh
+
+################################################################################
+# SETUP / TEARDOWN
+################################################################################
+
+setUp() {
+  #shellcheck source=../per_test_setup.sh
+  . ../per_test_setup.sh
+  writeConfigFiles
+}
+
+tearDown() {
+  # shellcheck source=../per_test_teardown.sh
+  . ../../per_test_teardown.sh
+}
+
+################################################################################
+# HELPER FUNCTIONS
+################################################################################
+
+writeConfigFiles() {
+  ./${EXEC_NAME} --generate-project-config --generate-cmakelists
+}
+
+useGnuCompilerHelper() {
+  cmd_output=$(${1})
+  exit_code=${?}
+  assertContains 'useGnuCompilerHelper compiler id' "${cmd_output}" 'The CXX compiler identification is GNU'
+  assertTrue 'useGnuCompilerHelper exec exists' '[ -e my-exec ]'
+  assertEquals 'useGnuCompilerHelper exit code' "${exit_code}" 0
+}
+
+useLlvmCompilerHelper() {
+  cmd_output=$(${1})
+  exit_code=${?}
+  assertContains 'useLlvmCompilerHelper compiler id' "${cmd_output}" 'The CXX compiler identification is Clang'
+  assertTrue 'useLlvmCompilerHelper exec exists' '[ -e my-exec ]'
+  assertEquals 'useLlvmCompilerHelper exit code' "${exit_code}" 0
+}
+
+################################################################################
+# UNIT TESTS
+################################################################################
+
+useGnuCompilerShort() {
+  useGnuCompilerHelper "./${EXEC_NAME} -dg"
+}
+
+useGnuCompilerLong() {
+  useGnuCompilerHelper "./${EXEC_NAME} -d --use-gnu-compiler"
+}
+
+useLlvmCompilerShort() {
+  useLlvmCompilerHelper "./${EXEC_NAME} -dl"
+}
+
+useLlvmCompilerLong() {
+  useLlvmCompilerHelper "./${EXEC_NAME} -d --use-llvm-compiler"
+}
+
+################################################################################
+# TEST SUITE
+################################################################################
+
+suite() {
+  # shellcheck disable=SC2154
+  if [ "${unit_test_function}" != ''  ] && [ "$( type -t "${unit_test_function}" )" = "function" ]; then
+    suite_addTest "${unit_test_function}"
+  else
+    suite_addTest useGnuCompilerShort
+    suite_addTest useGnuCompilerLong
+    suite_addTest useLlvmCompilerShort
+    suite_addTest useLlvmCompilerLong
+  fi
+}
+
+################################################################################
+# LOAD TEST FRAMEWORK (MUST GO LAST)
+################################################################################
+
+# zsh compatibility options
+export SHUNIT_PARENT=$0
+setopt shwordsplit 2> /dev/null
+# shellcheck disable=SC1091
+. "${PATH_TO_SHUNIT}"
+


### PR DESCRIPTION
## Description

Add cmd-line option to force use of GNU gcc/g++ compiler or LLVM clang/clang++ compiler (instead of system-default compiler).

Closes #1

## Type Of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Tests Performed

Ran `tests/test_driver.sh` on local machine. All tests pass.

**Test Configuration**:
* Hardware: Quad-Core i7, 16GB RAM
* OS: Arch Linux
* OS Release/Distribution: N/A
* Date Of Last OS Update: January 2019
* Compiler Version: gcc 8.2.1, clang 7.0.0
* Shell: bash, mksh, dash, zsh

## Checklist:

- [X] My code follows the style of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have added tests that prove my fix is effective or that my feature
      works.
- [X] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream
      modules... N/A