### PR TITLE
Implement useful exit codes

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -152,7 +152,7 @@ my-test-driver
 
 ## Full Usage / Options
 
-USAGE
+USAGE:
 
 `smart-build.sh  -h`
 
@@ -229,6 +229,18 @@ OPTIONS:
 
 `-q, --quiet-mode`  
 &nbsp; &nbsp; &nbsp; &nbsp; quiet mode
+
+EXIT CODES:
+
+&nbsp; &nbsp; &nbsp; &nbsp; `0` &nbsp; &nbsp; ok
+
+&nbsp; &nbsp; &nbsp; &nbsp; `1` &nbsp; &nbsp; usage, arguments, or options error
+
+&nbsp; &nbsp; &nbsp; &nbsp; `2` &nbsp; &nbsp; build error
+
+&nbsp; &nbsp; &nbsp; &nbsp; `3` &nbsp; &nbsp; test error
+
+&nbsp; &nbsp; `255` &nbsp; &nbsp; unknown error
 
 ## Examples
 

--- a/tests/unit_tests/bad_builds_and_tests_test.sh
+++ b/tests/unit_tests/bad_builds_and_tests_test.sh
@@ -1,0 +1,107 @@
+#!/bin/sh
+
+################################################################################
+# ENV VARS
+#   unit_test_function  optional single test function to run in this file
+################################################################################
+
+################################################################################
+# LOAD COMMON VARS
+################################################################################
+
+#shellcheck source=../unit_test_vars.sh
+. ../unit_test_vars.sh
+
+################################################################################
+# SETUP / TEARDOWN
+################################################################################
+
+setUp() {
+  #shellcheck source=../per_test_setup.sh
+  . ../per_test_setup.sh
+  writeConfigFiles
+}
+
+tearDown() {
+  # shellcheck source=../per_test_teardown.sh
+  . ../../per_test_teardown.sh
+}
+
+################################################################################
+# HELPER FUNCTIONS
+################################################################################
+
+writeConfigFiles() {
+  ./${EXEC_NAME} --generate-project-config --generate-cmakelists
+}
+
+################################################################################
+# UNIT TESTS
+################################################################################
+
+badCmakeConfigure() {
+  sed -i '16s/main/bad_main/' .project_config
+  cmd_output=$(./${EXEC_NAME} -dt 2>&1)
+  exit_code=${?}
+  assertContains 'badCmakeConfigure cmake error' "${cmd_output}" 'CMake Error at CMakeLists.txt'
+  assertNotContains 'badCmakeConfigure linking exec' "${cmd_output}" 'Linking CXX executable my-exec'
+  assertNotContains 'badCmakeConfigure building exec' "${cmd_output}" 'Built target my-exec'
+  assertNotContains 'badCmakeConfigure unit tests' "${cmd_output}" '[doctest] Status'
+  assertNotContains 'badCmakeConfigure ctest' "${cmd_output}" '% tests passed, '
+  assertFalse 'badCmakeConfigure exec exists' '[ -e my-exec ]'
+  assertFalse 'badCmakeConfigure test-driver exists' '[ -e my-test-driver ]'
+  assertEquals 'badCmakeConfigure exit code' "${exit_code}" 2
+}
+
+badCmakeBuild() {
+  sed -i '2s/Hello/Yello/' src/somea/Hello.cpp
+  cmd_output=$(./${EXEC_NAME} -dt 2>&1)
+  exit_code=${?}
+  assertContains 'badCmakeBuild cmake error' "${cmd_output}" 'compilation terminated'
+  assertNotContains 'badCmakeBuild linking exec' "${cmd_output}" 'Linking CXX executable my-exec'
+  assertNotContains 'badCmakeBuild building exec' "${cmd_output}" 'Built target my-exec'
+  assertNotContains 'badCmakeBuild unit tests' "${cmd_output}" '[doctest] Status'
+  assertNotContains 'badCmakeBuild ctest' "${cmd_output}" '% tests passed, '
+  assertFalse 'badCmakeBuild exec exists' '[ -e my-exec ]'
+  assertFalse 'badCmakeBuild test-driver exists' '[ -e my-test-driver ]'
+  assertEquals 'badCmakeBuild exit code' "${exit_code}" 2
+}
+
+badUnitTestResults() {
+  sed -i '8s/CHECK_NE/CHECK_EQ/' tests/unit_tests/Goodbye_test.cpp
+  cmd_output=$(./${EXEC_NAME} -dt 2>&1)
+  exit_code=${?}
+  assertContains 'badUnitTestResults linking exec' "${cmd_output}" 'Linking CXX executable my-exec'
+  assertContains 'badUnitTestResults building exec' "${cmd_output}" 'Built target my-exec'
+  assertContains 'badUnitTestResults unit tests' "${cmd_output}" '[doctest] Status: FAILURE!'
+  assertNotContains 'badUnitTestResults ctest' "${cmd_output}" '% tests passed, '
+  assertTrue 'badUnitTestResults exec exists' '[ -e my-exec ]'
+  assertTrue 'badUnitTestResults test-driver exists' '[ -e my-test-driver ]'
+  assertEquals 'badUnitTestResults exit code' "${exit_code}" 3
+}
+
+################################################################################
+# TEST SUITE
+################################################################################
+
+suite() {
+  # shellcheck disable=SC2154
+  if [ "${unit_test_function}" != ''  ] && [ "$( type -t "${unit_test_function}" )" = "function" ]; then
+    suite_addTest "${unit_test_function}"
+  else
+    suite_addTest badCmakeConfigure
+    suite_addTest badCmakeBuild
+    suite_addTest badUnitTestResults
+  fi
+}
+
+################################################################################
+# LOAD TEST FRAMEWORK (MUST GO LAST)
+################################################################################
+
+# zsh compatibility options
+export SHUNIT_PARENT=$0
+setopt shwordsplit 2> /dev/null
+# shellcheck disable=SC1091
+. "${PATH_TO_SHUNIT}"
+

--- a/tests/unit_tests/compile_link_test.sh
+++ b/tests/unit_tests/compile_link_test.sh
@@ -44,6 +44,10 @@ buildWithoutTests() {
   exit_code=${?}
   assertContains 'buildWithoutTests linking exec' "${cmd_output}" 'Linking CXX executable my-exec'
   assertContains 'buildWithoutTests building exec' "${cmd_output}" 'Built target my-exec'
+  assertNotContains 'buildWithoutTests linking test-driver' "${cmd_output}" 'Linking CXX executable my-test-driver'
+  assertNotContains 'buildWithoutTests building test-driver' "${cmd_output}" 'Built target my-test-driver'
+  assertNotContains 'buildWithoutTests unit tests' "${cmd_output}" '[doctest] Status: SUCCESS!'
+  assertNotContains 'buildWithoutTests ctest' "${cmd_output}" '% tests passed, '
   assertTrue 'buildWithoutTests exec exists' '[ -e my-exec ]'
   assertFalse 'buildWithoutTests test-driver exists' '[ -e my-test-driver ]'
   assertEquals 'buildWithoutTests exit code' "${exit_code}" 0
@@ -53,11 +57,15 @@ repeatBuildWithoutTests() {
   cmd_output=$(./${EXEC_NAME} -d)
   cmd_output=$(./${EXEC_NAME} -d)
   exit_code=${?}
-  assertNotContains 'buildWithoutTests linking exec' "${cmd_output}" 'Linking CXX executable my-exec'
-  assertContains 'buildWithoutTests building exec' "${cmd_output}" 'Built target my-exec'
-  assertTrue 'buildWithoutTests exec exists' '[ -e my-exec ]'
-  assertFalse 'buildWithoutTests test-driver exists' '[ -e my-test-driver ]'
-  assertEquals 'buildWithoutTests exit code' "${exit_code}" 0
+  assertNotContains 'repeatBuildWithoutTests linking exec' "${cmd_output}" 'Linking CXX executable my-exec'
+  assertContains 'repeatBuildWithoutTests building exec' "${cmd_output}" 'Built target my-exec'
+  assertNotContains 'repeatBuildWithoutTests linking test-driver' "${cmd_output}" 'Linking CXX executable my-test-driver'
+  assertNotContains 'repeatBuildWithoutTests building test-driver' "${cmd_output}" 'Built target my-test-driver'
+  assertNotContains 'repeatBuildWithoutTests unit tests' "${cmd_output}" '[doctest] Status: SUCCESS!'
+  assertNotContains 'repeatBuildWithoutTests ctest' "${cmd_output}" '% tests passed, '
+  assertTrue 'repeatBuildWithoutTests exec exists' '[ -e my-exec ]'
+  assertFalse 'repeatBuildWithoutTests test-driver exists' '[ -e my-test-driver ]'
+  assertEquals 'repeatBuildWithoutTests exit code' "${exit_code}" 0
 }
 
 buildWithTests() {
@@ -67,7 +75,8 @@ buildWithTests() {
   assertContains 'buildWithTests building exec' "${cmd_output}" 'Built target my-exec'
   assertContains 'buildWithTests linking test-driver' "${cmd_output}" 'Linking CXX executable my-test-driver'
   assertContains 'buildWithTests building test-driver' "${cmd_output}" 'Built target my-test-driver'
-  assertContains 'buildWithTests tests passed' "${cmd_output}" '100% tests passed, 0 tests failed'
+  assertContains 'buildWithTests unit tests' "${cmd_output}" '[doctest] Status: SUCCESS!'
+  assertNotContains 'buildWithTests ctest' "${cmd_output}" '% tests passed, '
   assertTrue 'buildWithTests exec exists' '[ -e my-exec ]'
   assertTrue 'buildWithTests test-driver exists' '[ -e my-test-driver ]'
   assertEquals 'buildWithTests exit code' "${exit_code}" 0
@@ -81,7 +90,8 @@ repeatBuildWithTests() {
   assertContains 'repeatBuildWithTests building exec' "${cmd_output}" 'Built target my-exec'
   assertNotContains 'repeatBuildWithTests linking test-driver' "${cmd_output}" 'Linking CXX executable my-test-driver'
   assertContains 'repeatBuildWithTests building test-driver' "${cmd_output}" 'Built target my-test-driver'
-  assertContains 'repeatBuildWithTests tests passed' "${cmd_output}" '100% tests passed, 0 tests failed'
+  assertContains 'repeatBuildWithTests unit tests' "${cmd_output}" '[doctest] Status: SUCCESS!'
+  assertNotContains 'repeatBuildWithTests ctest' "${cmd_output}" '% tests passed, '
   assertTrue 'repeatBuildWithTests exec exists' '[ -e my-exec ]'
   assertTrue 'repeatBuildWithTests test-driver exists' '[ -e my-test-driver ]'
   assertEquals 'repeatBuildWithTests exit code' "${exit_code}" 0
@@ -94,7 +104,8 @@ buildTestsOnly() {
   assertNotContains 'buildTestsOnly building exec' "${cmd_output}" 'Built target my-exec'
   assertContains 'buildTestsOnly linking test-driver' "${cmd_output}" 'Linking CXX executable my-test-driver'
   assertContains 'buildTestsOnly building test-driver' "${cmd_output}" 'Built target my-test-driver'
-  assertContains 'buildTestsOnly tests passed' "${cmd_output}" '100% tests passed, 0 tests failed'
+  assertContains 'buildTestsOnly unit tests' "${cmd_output}" '[doctest] Status: SUCCESS!'
+  assertNotContains 'buildTestsOnly ctest' "${cmd_output}" '% tests passed, '
   assertFalse 'buildTestsOnly exec exists' '[ -e my-exec ]'
   assertTrue 'buildTestsOnly test-driver exists' '[ -e my-test-driver ]'
   assertEquals 'buildTestsOnly exit code' "${exit_code}" 0
@@ -108,7 +119,8 @@ repeatBuildTestsOnly() {
   assertNotContains 'repeatBuildTestsOnly building exec' "${cmd_output}" 'Built target my-exec'
   assertNotContains 'repeatBuildTestsOnly linking test-driver' "${cmd_output}" 'Linking CXX executable my-test-driver'
   assertContains 'repeatBuildTestsOnly building test-driver' "${cmd_output}" 'Built target my-test-driver'
-  assertContains 'repeatBuildTestsOnly tests passed' "${cmd_output}" '100% tests passed, 0 tests failed'
+  assertContains 'repeatBuildTestsOnly unit tests' "${cmd_output}" '[doctest] Status: SUCCESS!'
+  assertNotContains 'repeatBuildTestsOnly ctest' "${cmd_output}" '% tests passed, '
   assertFalse 'repeatBuildTestsOnly exec exists' '[ -e my-exec ]'
   assertTrue 'repeatBuildTestsOnly test-driver exists' '[ -e my-test-driver ]'
   assertEquals 'repeatBuildTestsOnly exit code' "${exit_code}" 0

--- a/tests/unit_tests/no_build_exec_test.sh
+++ b/tests/unit_tests/no_build_exec_test.sh
@@ -44,10 +44,11 @@ noBuildExecFromConfigFileWithTests() {
   sed -i '18s/.*/-/' .project_config
   cmd_output=$(./${EXEC_NAME} -dt)
   exit_code=${?}
-  assertContains 'no-build-exec from config file with tests output' "${cmd_output}" '100% tests passed, 0 tests failed'
-  assertTrue 'no-build-exec from config file with tests exec' '[ ! -e my-exec ]'
-  assertTrue 'no-build-exec from config file with tests test driver' '[ -e my-test-driver ]'
-  assertEquals 'no-build-exec from config file with tests exit code' "${exit_code}" 0
+  assertContains 'noBuildExecFromConfigFileWithTests unit tests' "${cmd_output}" '[doctest] Status: SUCCESS!'
+  assertNotContains 'noBuildExecFromConfigFileWithTests ctest' "${cmd_output}" '% tests passed, '
+  assertTrue 'noBuildExecFromConfigFileWithTests exec' '[ ! -e my-exec ]'
+  assertTrue 'noBuildExecFromConfigFileWithTests test driver' '[ -e my-test-driver ]'
+  assertEquals 'noBuildExecFromConfigFileWithTests exit code' "${exit_code}" 0
 }
 
 noBuildExecFromConfigFileWithoutTests() {
@@ -55,10 +56,10 @@ noBuildExecFromConfigFileWithoutTests() {
   sed -i '18s/.*/-/' .project_config
   cmd_output=$(./${EXEC_NAME} -d)
   exit_code=${?}
-  assertContains 'no-build-exec from config file without tests output' "${cmd_output}" 'Built target user_lib'
-  assertTrue 'no-build-exec from config file without tests exec' '[ ! -e my-exec ]'
-  assertTrue 'no-build-exec from config file without tests test driver' '[ ! -e my-test-driver ]'
-  assertEquals 'no-build-exec from config file without tests exit code' "${exit_code}" 0
+  assertContains 'noBuildExecFromConfigFileWithoutTests output' "${cmd_output}" 'Built target user_lib'
+  assertTrue 'noBuildExecFromConfigFileWithoutTests exec' '[ ! -e my-exec ]'
+  assertTrue 'noBuildExecFromConfigFileWithoutTests test driver' '[ ! -e my-test-driver ]'
+  assertEquals 'noBuildExecFromConfigFileWithoutTests exit code' "${exit_code}" 0
 }
 
 noBuildExecFromConfigFileAndCmdOpt() {
@@ -66,38 +67,38 @@ noBuildExecFromConfigFileAndCmdOpt() {
   sed -i '18s/.*/-/' .project_config
   cmd_output=$(./${EXEC_NAME} -dE)
   exit_code=${?}
-  assertContains 'no-build-exec from config file and cmd opt output' "${cmd_output}" 'Built target user_lib'
-  assertTrue 'no-build-exec from config file and cmd opt exec' '[ ! -e my-exec ]'
-  assertTrue 'no-build-exec from config file and cmd opt test driver' '[ ! -e my-test-driver ]'
-  assertEquals 'no-build-exec from config file and cmd opt exit code' "${exit_code}" 0
+  assertContains 'noBuildExecFromConfigFileAndCmdOpt output' "${cmd_output}" 'Built target user_lib'
+  assertTrue 'noBuildExecFromConfigFileAndCmdOpt exec' '[ ! -e my-exec ]'
+  assertTrue 'noBuildExecFromConfigFileAndCmdOpt test driver' '[ ! -e my-test-driver ]'
+  assertEquals 'noBuildExecFromConfigFileAndCmdOpt exit code' "${exit_code}" 0
 }
 
 noBuildExecFromConfigFileBadInput() {
   sed -i '18s/.*/-/' .project_config
   cmd_output=$(./${EXEC_NAME} -d)
   exit_code=${?}
-  assertContains 'no-build-exec from config file bad input output' "${cmd_output}" 'main executable source file specified, but exec name missing'
-  assertTrue 'no-build-exec from config file bad input exec' '[ ! -e my-exec ]'
-  assertTrue 'no-build-exec from config file bad input test driver' '[ ! -e my-test-driver ]'
-  assertEquals 'no-build-exec from config file bad input exit code' "${exit_code}" 2
+  assertContains 'noBuildExecFromConfigFileBadInput output' "${cmd_output}" 'main executable source file specified, but exec name missing'
+  assertTrue 'noBuildExecFromConfigFileBadInput exec' '[ ! -e my-exec ]'
+  assertTrue 'noBuildExecFromConfigFileBadInput test driver' '[ ! -e my-test-driver ]'
+  assertEquals 'noBuildExecFromConfigFileBadInput exit code' "${exit_code}" 1
 }
 
 noBuildExecFromCmdOptShort() {
   cmd_output=$(./${EXEC_NAME} -d -E)
   exit_code=${?}
-  assertContains 'no-build-exec from cmd opt short output' "${cmd_output}" 'Built target user_lib'
-  assertTrue 'no-build-exec from cmd opt short exec' '[ ! -e my-exec ]'
-  assertTrue 'no-build-exec from cmd opt short test driver' '[ ! -e my-test-driver ]'
-  assertEquals 'no-build-exec from cmd opt short exit code' "${exit_code}" 0
+  assertContains 'noBuildExecFromCmdOptShort output' "${cmd_output}" 'Built target user_lib'
+  assertTrue 'noBuildExecFromCmdOptShort exec' '[ ! -e my-exec ]'
+  assertTrue 'noBuildExecFromCmdOptShort test driver' '[ ! -e my-test-driver ]'
+  assertEquals 'noBuildExecFromCmdOptShort exit code' "${exit_code}" 0
 }
 
 noBuildExecFromCmdOptLong() {
   cmd_output=$(./${EXEC_NAME} -d --no-build-executable)
   exit_code=${?}
-  assertContains 'no-build-exec from cmd opt long output' "${cmd_output}" 'Built target user_lib'
-  assertTrue 'no-build-exec from cmd opt long exec' '[ ! -e my-exec ]'
-  assertTrue 'no-build-exec from cmd opt long test driver' '[ ! -e my-test-driver ]'
-  assertEquals 'no-build-exec from cmd opt long exit code' "${exit_code}" 0
+  assertContains 'noBuildExecFromCmdOptLong output' "${cmd_output}" 'Built target user_lib'
+  assertTrue 'noBuildExecFromCmdOptLong exec' '[ ! -e my-exec ]'
+  assertTrue 'noBuildExecFromCmdOptLong test driver' '[ ! -e my-test-driver ]'
+  assertEquals 'noBuildExecFromCmdOptLong exit code' "${exit_code}" 0
 }
 
 ################################################################################

--- a/tests/unit_tests/project_config_test.sh
+++ b/tests/unit_tests/project_config_test.sh
@@ -37,12 +37,13 @@ alternateProjectConfigHelper() {
   sed -i '26s/.*/alt-test-driver/' .alt_project_config
   cmd_output=$(${1})
   exit_code=${?}
-  assertTrue 'Basic .project_config builds and tests' '[ ! -e my-exec ]'
-  assertTrue 'Basic .project_config builds and tests' '[ ! -e my-test-driver ]'
-  assertTrue 'Basic .project_config builds and tests' '[ -e alt-exec ]'
-  assertTrue 'Basic .project_config builds and tests' '[ -e alt-test-driver ]'
-  assertContains 'Basic .project_config builds and tests' "${cmd_output}" '100% tests passed, 0 tests failed'
-  assertEquals 'Basic .project_config builds and tests' "${exit_code}" 0
+  assertFalse 'alternateProjectConfigHelper exec exists' '[ -e my-exec ]'
+  assertFalse 'alternateProjectConfigHelper test-driver exists' '[ -e my-test-driver ]'
+  assertTrue 'alternateProjectConfigHelper alt-exec exists' '[ -e alt-exec ]'
+  assertTrue 'alternateProjectConfigHelper alt-test-driver exists' '[ -e alt-test-driver ]'
+  assertContains 'alternateProjectConfigHelper unit tests' "${cmd_output}" '[doctest] Status: SUCCESS!'
+  assertNotContains 'alternateProjectConfigHelper ctest' "${cmd_output}" '% tests passed, '
+  assertEquals 'alternateProjectConfigHelper exit code' "${exit_code}" 0
 }
 
 writeConfigFiles() {
@@ -56,18 +57,19 @@ writeConfigFiles() {
 missingProjectConfig() {
   cmd_output=$(./${EXEC_NAME})
   exit_code=${?}
-  assertContains 'Invocation with missing .project_config' "${cmd_output}" 'could not open project config file ".project_config"'
-  assertEquals 'Invocation with missing .project_config' "${exit_code}" 1
+  assertContains 'missingProjectConfig output' "${cmd_output}" 'could not open project config file ".project_config"'
+  assertEquals 'missingProjectConfig exit code' "${exit_code}" 1
 }
 
 basicProjectConfigBuildsAndTests() {
   writeConfigFiles
   cmd_output=$(./${EXEC_NAME} --build-type-debug --make-and-run-tests)
   exit_code=${?}
-  assertTrue 'Basic .project_config builds and tests' '[ -e my-exec ]'
-  assertTrue 'Basic .project_config builds and tests' '[ -e my-test-driver ]'
-  assertContains 'Basic .project_config builds and tests' "${cmd_output}" '100% tests passed, 0 tests failed'
-  assertEquals 'Basic .project_config builds and tests' "${exit_code}" 0
+  assertTrue 'basicProjectConfigBuildsAndTests exec exists' '[ -e my-exec ]'
+  assertTrue 'basicProjectConfigBuildsAndTests test driver exists' '[ -e my-test-driver ]'
+  assertContains 'basicProjectConfigBuildsAndTests unit tests' "${cmd_output}" '[doctest] Status: SUCCESS!'
+  assertNotContains 'basicProjectConfigBuildsAndTests ctest' "${cmd_output}" '% tests passed, '
+  assertEquals 'basicProjectConfigBuildsAndTests exit code' "${exit_code}" 0
 }
 
 alternateProjectConfigShort() {

--- a/tests/unit_tests/test_test.sh
+++ b/tests/unit_tests/test_test.sh
@@ -38,19 +38,21 @@ writeConfigFiles() {
 makeAndRunTests() {
   cmd_output=$(${1})
   exit_code=${?}
-  assertContains 'make-and-run-tests output' "${cmd_output}" '100% tests passed, 0 tests failed'
-  assertTrue 'make-and-run-tests exec' '[ -e my-exec ]'
-  assertTrue 'make-and-run-tests test driver' '[ -e my-test-driver ]'
-  assertEquals 'make-and-run-tests exit code' "${exit_code}" 0
+  assertContains 'makeAndRunTests unit tests' "${cmd_output}" '[doctest] Status: SUCCESS!'
+  assertNotContains 'makeAndRunTests ctest' "${cmd_output}" '% tests passed, '
+  assertTrue 'makeAndRunTests exec' '[ -e my-exec ]'
+  assertTrue 'makeAndRunTests test driver' '[ -e my-test-driver ]'
+  assertEquals 'makeAndRunTests exit code' "${exit_code}" 0
 }
 
 makeTests() {
   cmd_output=$(${1})
   exit_code=${?}
-  assertNotContains 'make-and-run-tests output' "${cmd_output}" '100% tests passed, 0 tests failed'
-  assertTrue 'make-and-run-tests exec' '[ -e my-exec ]'
-  assertTrue 'make-and-run-tests test driver' '[ -e my-test-driver ]'
-  assertEquals 'make-and-run-tests exit code' "${exit_code}" 0
+  assertNotContains 'makeTests unit tests' "${cmd_output}" '[doctest] Status: SUCCESS!'
+  assertNotContains 'makeTests ctest' "${cmd_output}" '% tests passed, '
+  assertTrue 'makeTests exec' '[ -e my-exec ]'
+  assertTrue 'makeTests test driver' '[ -e my-test-driver ]'
+  assertEquals 'makeTests exit code' "${exit_code}" 0
 }
 
 ################################################################################


### PR DESCRIPTION
## Description

Return appropriate exit codes for bad usage, bad build, bad test results, etc. If any of one of these operations is "bad," exit immediately (instead of current logic, which continues and attempts to run tests on a bad build...). Also, run unit tester (doctest) directly instead of via ctest - better unit test feedback this way, and reserves ctest for running a battery of tests.

Closes #2 Make smart-build return useful error codes.

## Type Of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [X] This change requires a documentation update

## Tests Performed

All unit tests in `tests/test_driver.sh` pass.

**Test Configuration**:
* Hardware: Quad Core i7, 16 GB RAM
* OS: Arch Linux
* OS Release/Distribution: N/A
* Date Of Last OS Update: January 2019
* Compiler Version: gcc 8.2.1, clang 7.0.0
* Shell: bash, mksh, dash, zsh

## Checklist:

- [X] My code follows the style of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have added tests that prove my fix is effective or that my feature
      works.
- [X] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream
      modules.... _N/A_

